### PR TITLE
Code cleanup, better error handing, unittests and more examples

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -7,9 +7,11 @@
 2. Build the extension:
 $ cd phprados
 $ phpize
-$ ./configure
+$ ./configure --enable-procedural --enable--oo
 $ make
 $ make install
+
+If you would only require the procedural interface to build leave out the --enable--oo.
 
 3. Loading the extension
 Add "extension=rados.so" to your php.ini

--- a/README
+++ b/README
@@ -42,4 +42,7 @@ $ pear config-set auto_discover 1
 $ pear install pear.phpunit.de/PHPUnit
 
 Running the tests is simple:
+$ export id="admin"
+$ export key="your-key-found-in-your-ceph.keyring"
+$ export mon_host="ip-of-your-monitor-host"
 $ phpunit

--- a/config.m4
+++ b/config.m4
@@ -1,6 +1,13 @@
 PHP_ARG_ENABLE(rados, [Enable the rados extension],
     [  --enable-rados[=DIR]      Enable "RADOS" extension support], no)
 
+PHP_ARG_ENABLE(procedural, [Enable the rados procedural interface],
+    [  --enable-procedural     Enable "RADOS" procedural interface], yes, no)
+
+PHP_ARG_ENABLE(oo, [Enable the rados OO interface],
+    [  --enable-oo             Enable "RADOS" OO interface], no, no)
+
+
 if test $PHP_RADOS != "no"; then
 
     AC_MSG_CHECKING([for RADOS files (librados.h)])
@@ -35,7 +42,23 @@ if test $PHP_RADOS != "no"; then
     else
         PHP_ADD_LIBRARY_WITH_PATH(crypto, $CRYPTO_DIR/$PHP_LIBDIR, RADOS_SHARED_LIBADD)
     fi
+	
+	if test $PHP_PROCEDURAL == "yes"; then
+		AC_DEFINE(BUILD_PROCEDURAL, 1, [ Whether to build the procedural api])
+	fi
 
-    PHP_SUBST(RADOS_SHARED_LIBADD)
-    PHP_NEW_EXTENSION(rados, [rados.c], $ext_shared)
+	if test $PHP_OO == "yes"; then
+		AC_DEFINE(BUILD_OO, 1, [Whether to build the OO api])
+	fi
+
+	if test $PHP_OO != "no"; then
+		PHP_SUBST(RADOS_SHARED_LIBADD)
+		PHP_REQUIRE_CXX()
+		PHP_SUBST(VEHICLES_SHARED_LIBADD)
+		PHP_ADD_LIBRARY(stdc++, 1, RADOS_SHARED_LIBADD)
+		PHP_NEW_EXTENSION(rados, [php_rados.cc rados_oo.cc], $ext_shared)
+	else
+		PHP_SUBST(RADOS_SHARED_LIBADD)
+		PHP_NEW_EXTENSION(rados, [php_rados.cc], $ext_shared)
+	fi
 fi

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,7 +6,7 @@ The phprados extension comes in two flavors:
 
 For both interfaces examples can be found in this directory.
 
-Some examples require a pool named 'example'. Create it in advanced or use
+Some examples require a pool named 'phprados'. Create it in advanced or use
 one of the create-pool examples to create this pool.
 
 Procedural interface

--- a/examples/oo-connect-with-config-file.php
+++ b/examples/oo-connect-with-config-file.php
@@ -16,5 +16,5 @@
 	print __LINE__."\tConnect to the cluster\n";
 	$rados->connect();
 	
-	print __LINE__."\Select a pool 'example'\n";
-	$rados->selectPool("example");
+	print __LINE__."\tSelect a pool 'example'\n";
+	$rados->selectPool("phprados");

--- a/examples/oo-connect-without-config-file.php
+++ b/examples/oo-connect-without-config-file.php
@@ -13,9 +13,9 @@
      * 
      */
     
-    $mon_host = "193.104.8.235";
-    $key      = "AQD733tRUCooCBAA4DGA+xY1Z4+mm8rB4eGaEA==";
-    $pool     = "example";
+    $mon_host = "127.0.0.1";
+    $key      = "__YOUR_KEY_GOES_HERE__";
+    $pool     = "phprados";
     
     print __LINE__."\tCreate a new object\n";
 	$rados = new Rados();
@@ -30,7 +30,7 @@
 	$rados->connect();
 	
 	print __LINE__."\tSelect a pool 'example'\n";
-	$rados->selectPool("example");
+	$rados->selectPool($pool);
 
     // The next line is a short cut to the above
     // $rados->connect($mon_host, $key, $pool);

--- a/examples/oo-create-pool.php
+++ b/examples/oo-create-pool.php
@@ -9,4 +9,4 @@
 	$rados->connect();
 	
 	print __LINE__."\tCreate a pool 'example'\n";
-	$rados->createPool("example");
+	$rados->createPool("phprados");

--- a/examples/oo-destroy-pool.php
+++ b/examples/oo-destroy-pool.php
@@ -8,5 +8,5 @@
 	print __LINE__."\tConnect to the cluster\n";
 	$rados->connect();
 		
-	print __LINE__."\tDestroy (!DELETE!) the 'example' pool\n";
-	$rados->destroyPool("example");
+	print __LINE__."\tDestroy (!DELETE!) the 'phprados' pool\n";
+	$rados->destroyPool("phprados");

--- a/examples/oo-test.php
+++ b/examples/oo-test.php
@@ -1,5 +1,0 @@
-<?php
-    $rados = new Rados();
-    $x = $rados->connect("127.012","");
-    var_dump($x);
-    print $rados->getLastError();

--- a/examples/oo-write-read-data.php
+++ b/examples/oo-write-read-data.php
@@ -8,8 +8,8 @@
 	print __LINE__."\tConnect to the cluster\n";
 	$rados->connect();
 		
-	print __LINE__."\tSelect pool 'example'\n";        
-    $rados->selectPool('example');
+	print __LINE__."\tSelect pool 'phprados'\n";        
+    $rados->selectPool("phprados");
     
 	print __LINE__."\tWrite some data...'\n";
 	$rados->write("unique-id","Some random data\n");

--- a/php_rados.h
+++ b/php_rados.h
@@ -2,7 +2,7 @@
 #define PHP_RADOS_H
 
 #define PHP_RADOS_EXTNAME  "rados"
-#define PHP_RADOS_EXTVER   "0.9.4-002"
+#define PHP_RADOS_EXTVER   "0.9.4-003"
 
 #include "php.h"
 #include "php_ini.h"

--- a/test/UnitTestOO.php
+++ b/test/UnitTestOO.php
@@ -14,11 +14,14 @@
 
 class RadosTest extends PHPUnit_Framework_TestCase {
 	
+	/**
+      * Test if it's possible to create a Rados object
+     */    
 	public function testRadosCreateObject() {
 		$object = new Rados();
 		$this->assertNotNull($object);
-		
-		return $object;
+        
+        return $object;
 	}
 	
 	    
@@ -45,8 +48,8 @@ class RadosTest extends PHPUnit_Framework_TestCase {
      */	
 	public function testRadosConnect($object) {
 		
-		$object->setOption("mon_host", getenv('mon_host'));
-		$object->setOption("key", getenv('key'));
+		$object->setOption('mon_host', getenv('mon_host'));
+		$object->setOption('key', getenv('key'));
 		$conn = $object->connect();
 
         $this->assertTrue($conn);
@@ -57,20 +60,16 @@ class RadosTest extends PHPUnit_Framework_TestCase {
 	/**
       * This test connects to the environment variable 'mon_host' with they key 'key'
       * using the short hand method of connect. Also selects pool $pool as it's pool.
-      *
-      * @depends testRadosCreatePool
-     */	
-	public function testRadosConnectShortHand($object) {
-		
+      *      
+      */	
+	public function testRadosConnectShortHand() {
 		$host = getenv('mon_host');
-		$key  = getenv('mon_host');
-		$pool = "oounittest";
+		$key  = getenv('key');
 		
-		$conn = $object->connect($host, $key, $pool);
+        $object = new Rados();
+		$conn = $object->connect($host, $key);
 
         $this->assertTrue($conn);
-
-        return $object;
     }
     
     /**
@@ -80,7 +79,22 @@ class RadosTest extends PHPUnit_Framework_TestCase {
      */	
 	public function testRadosCreatePool($object) {
 		
-		$result = $object->createPool("oounittest");
+		$result = $object->createPool('oounittest');
+		
+        $this->assertTrue($result);
+
+        return $object;
+    }
+
+
+    /**
+      * This test selects a pool
+      *
+      * @depends testRadosCreatePool
+     */	
+	public function testRadosSelectPool($object) {
+		
+		$result = $object->selectPool('oounittest');
 		
         $this->assertTrue($result);
 
@@ -88,20 +102,47 @@ class RadosTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-      * This test removes a pool
+      * This test writes data to the pool oounittest
       *
-      * @depends testRadosCreatePool
+      * @depends testRadosSelectPool
      */	
-	public function testRadosDestroyPool($object) {
+	public function testRadosWriteData($object) {
 		
-		$result = $object->destroyPool("oounittest");
+		$result = $object->write('unique-id','test_datum');
 		
         $this->assertTrue($result);
 
         return $object;
     }
     
-    
+    /**
+      * This test reads data from the pool oounittest
+      *
+      * @depends testRadosWriteData
+     */	
+	public function testRadosReadData($object) {
+		
+		$data = $object->read("unique-id");
+		
+        $this->assertEquals("test_datum", $data);
+        
+        return $object;
+    }
+
+    /**
+      * This test removes a pool
+      *
+      * @depends testRadosReadData
+     */	
+	public function testRadosDestroyPool($object) {
+		
+		$result = $object->destroyPool('oounittest');
+		
+        $this->assertTrue($result);
+
+        return $object;
+    }
+
 }
 
 ?>


### PR DESCRIPTION
The code got some cleanup to be more consistent and provide an API more similar than that of existing extensions (ex. mysqli).

The more common errors are handled for connect, selectPool and write.

A additional file with UnitTests for the OO interface has been added.

Some more examples are added to show the uses as also a Readme.md file providing an overview of the examples.
