### PR TITLE
Fixed: Memory allocation 

### DIFF
--- a/rados.c
+++ b/rados.c
@@ -714,7 +714,8 @@ PHP_FUNCTION(rados_read) {
         RETURN_FALSE;
     }
 
-    char buffer[size];
+    //char buffer[size];
+    char *buffer = emalloc(size * sizeof(char));
 
     ZEND_FETCH_RESOURCE(ioctx_r, php_rados_ioctx*, &zioctx, -1, PHP_RADOS_IOCTX_RES_NAME, le_rados_ioctx);
 

--- a/rados.c
+++ b/rados.c
@@ -720,10 +720,12 @@ PHP_FUNCTION(rados_read) {
     ZEND_FETCH_RESOURCE(ioctx_r, php_rados_ioctx*, &zioctx, -1, PHP_RADOS_IOCTX_RES_NAME, le_rados_ioctx);
 
     if (rados_read(ioctx_r->io, oid, buffer, size, offset) < 0) {
+        efree(buffer); //free the buffer is rados_read fails
         RETURN_FALSE;
+        return;
     }
 
-    RETURN_STRINGL(buffer, size, 1);
+    RETURN_STRINGL(buffer, size, 0); //passing by reference, the third param
 }
 
 PHP_FUNCTION(rados_remove) {


### PR DESCRIPTION
emalloc used for dynamic buffer allocation. For large object it was crashing.