### PR TITLE
add support for pool namespaces

### DIFF
--- a/php_rados.h
+++ b/php_rados.h
@@ -2,7 +2,7 @@
 #define PHP_RADOS_H
 
 #define PHP_RADOS_EXTNAME  "rados"
-#define PHP_RADOS_EXTVER   "0.9.3"
+#define PHP_RADOS_EXTVER   "0.9.4"
 
 #include "php.h"
 #include "php_ini.h"
@@ -28,6 +28,7 @@ typedef struct _php_rados_cluster {
 
 typedef struct _php_rados_ioctx {
     rados_ioctx_t io;
+    char *nspace;
 } php_rados_ioctx;
 
 PHP_MINIT_FUNCTION(rados);
@@ -79,6 +80,8 @@ PHP_FUNCTION(rados_get_instance_id);
 PHP_FUNCTION(rados_ioctx_create2);
 PHP_FUNCTION(rados_ioctx_get_id);
 PHP_FUNCTION(rados_ioctx_get_pool_name);
+PHP_FUNCTION(rados_ioctx_get_namespace);
+PHP_FUNCTION(rados_ioctx_set_namespace);
 
 extern zend_module_entry rados_module_entry;
 #define phpext_rados_ptr &rados_module_entry;

--- a/test/UnitTest.php
+++ b/test/UnitTest.php
@@ -222,6 +222,18 @@ class RadosTest extends PHPUnit_Framework_TestCase {
     public function testRadosShutDown($cluster) {
         $this->assertTrue(rados_shutdown($cluster));
     }
+
+    /**
+     * @depends testRadosCreateIoCTX
+     */
+    public function testRadosNamespace($ioctx) {
+        $this->assertNull(rados_ioctx_get_namespace($ioctx));
+        rados_ioctx_set_namespace($ioctx, "foo");
+        $name = rados_ioctx_get_namespace($ioctx);
+        $this->assertEquals($name, "foo");
+        rados_ioctx_set_namespace($ioctx, NULL);
+        $this->assertNull(rados_ioctx_get_namespace($ioctx));
+    }
 }
 
 ?>


### PR DESCRIPTION
The nspace value is held by implementation as in python rados lib (librados doesn't provide get method:(