### PR TITLE
bug fix:rados_ioctx_create return wrong io handler rather than wrong …

### DIFF
--- a/rados.c
+++ b/rados.c
@@ -567,13 +567,10 @@ PHP_FUNCTION(rados_ioctx_create)
     else {
         ioctx_r = (php_rados_ioctx *)emalloc(sizeof(php_rados_ioctx));
         ioctx_r->io = io;
+        ioctx_r->nspace = NULL;
         ZEND_REGISTER_RESOURCE(return_value, ioctx_r, le_rados_ioctx);
     }
 
-    ioctx_r = (php_rados_ioctx *)emalloc(sizeof(php_rados_ioctx));
-    ioctx_r->io = io;
-    ioctx_r->nspace = NULL;
-    ZEND_REGISTER_RESOURCE(return_value, ioctx_r, le_rados_ioctx);
 }
 
 PHP_FUNCTION(rados_ioctx_destroy)


### PR DESCRIPTION
…msg when

pool name doesn't exist