### PR TITLE
Adds pagination to rados_objects_list

### DIFF
--- a/php_rados.h
+++ b/php_rados.h
@@ -2,7 +2,7 @@
 #define PHP_RADOS_H
 
 #define PHP_RADOS_EXTNAME  "rados"
-#define PHP_RADOS_EXTVER   "0.9.4"
+#define PHP_RADOS_EXTVER   "0.9.5"
 
 #include "php.h"
 #include "php_ini.h"

--- a/rados.c
+++ b/rados.c
@@ -1242,19 +1242,20 @@ PHP_FUNCTION(rados_objects_list) {
     const char *oid;
     bool found_hash = false;
 
-    while (rados_objects_list_next(ctx, &oid, NULL) == 0 && (results <= limit || limit == 0)) {
-        // Check if we've found the object to start from yet
+    while (rados_objects_list_next(ctx, &oid, NULL) == 0 && (results < limit || limit == 0)) {
         if (start_object_name && !found_hash && strcmp(start_object_name, oid) != 0) {
-           continue;
+            // If they've specified an object to start from, and it doesnt match, then skip
+            continue;
+        } else if (start_object_name && !found_hash && strcmp(start_object_name, oid) == 0) {
+            // If this object matches exactly we want to skip it
+            found_hash = true;
+            continue;
         } else {
-           found_hash = true;
+            // We've been past the matching one (or no match was given)
+            found_hash = true;
         }
 
-        // Skip the first first one. 
-        if (!start_object_name || results > 0) {
-            add_next_index_string(return_value, oid, 1);
-        }
-
+        add_next_index_string(return_value, oid, 1);
         results++;
     }
 

--- a/rados.c
+++ b/rados.c
@@ -178,8 +178,8 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_rados_objects_list, 0, 0, 1)
     ZEND_ARG_INFO(0, ioctx)
-    ZEND_ARG_INFO(0, start_object_name)
     ZEND_ARG_INFO(0, limit)
+    ZEND_ARG_INFO(0, start_object_name)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_rados_ioctx_snap_create, 0)
@@ -1225,7 +1225,7 @@ PHP_FUNCTION(rados_objects_list) {
     uint64_t limit = 0;
     int results = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|sl", &zioctx, &start_object_name, &start_object_name_len, &limit) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|ls", &zioctx, &limit, &start_object_name, &start_object_name_len) == FAILURE) {
         RETURN_FALSE;
     }
 

--- a/rados.c
+++ b/rados.c
@@ -176,8 +176,10 @@ ZEND_BEGIN_ARG_INFO(arginfo_rados_getxattrs, 0)
     ZEND_ARG_INFO(0, oid)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_rados_objects_list, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_rados_objects_list, 0, 0, 1)
     ZEND_ARG_INFO(0, ioctx)
+    ZEND_ARG_INFO(0, start_object_name)
+    ZEND_ARG_INFO(0, limit)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_rados_ioctx_snap_create, 0)
@@ -1218,22 +1220,47 @@ PHP_FUNCTION(rados_objects_list) {
     php_rados_ioctx *ioctx_r;
     zval *zioctx;
     rados_list_ctx_t ctx;
+    char *start_object_name = NULL;
+    int *start_object_name_len = 0;
+    uint64_t limit = 0;
+    int results = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zioctx) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r|sl", &zioctx, &start_object_name, &start_object_name_len, &limit) == FAILURE) {
         RETURN_FALSE;
     }
 
-    ZEND_FETCH_RESOURCE(ioctx_r, php_rados_ioctx*, &zioctx, -1, PHP_RADOS_IOCTX_RES_NAME, le_rados_ioctx);
+    if (limit < 0) {
+        limit = 0;
+    }
 
     array_init(return_value);
 
+    ZEND_FETCH_RESOURCE(ioctx_r, php_rados_ioctx*, &zioctx, -1, PHP_RADOS_IOCTX_RES_NAME, le_rados_ioctx);
+    
     rados_objects_list_open(ioctx_r->io, &ctx);
+
     const char *oid;
-    while (rados_objects_list_next(ctx, &oid, NULL) == 0) {
-        add_next_index_string(return_value, oid, 1);
+    bool found_hash = false;
+
+    while (rados_objects_list_next(ctx, &oid, NULL) == 0 && (results <= limit || limit == 0)) {
+        // Check if we've found the object to start from yet
+        if (start_object_name && !found_hash && strcmp(start_object_name, oid) != 0) {
+           continue;
+        } else {
+           found_hash = true;
+        }
+
+        // Skip the first first one. 
+        if (results > 0) {
+            add_next_index_string(return_value, oid, 1);
+        }
+
+        results++;
     }
+
     rados_objects_list_close(ctx);
 }
+
 
 PHP_FUNCTION(rados_ioctx_snap_create) {
     php_rados_ioctx *ioctx_r;
@@ -1253,7 +1280,6 @@ PHP_FUNCTION(rados_ioctx_snap_create) {
     }
 
     ZEND_FETCH_RESOURCE(ioctx_r, php_rados_ioctx*, &zioctx, -1, PHP_RADOS_IOCTX_RES_NAME, le_rados_ioctx);
-
 
     response = rados_ioctx_snap_create(ioctx_r->io, snapname);
 

--- a/rados.c
+++ b/rados.c
@@ -1251,7 +1251,7 @@ PHP_FUNCTION(rados_objects_list) {
         }
 
         // Skip the first first one. 
-        if (results > 0) {
+        if (!start_object_name || results > 0) {
             add_next_index_string(return_value, oid, 1);
         }
 

--- a/test/ListObjectsUnitTest.php
+++ b/test/ListObjectsUnitTest.php
@@ -1,0 +1,64 @@
+<?php
+
+class ListObjectsUnitTest extends PHPUnit_Framework_TestCase
+{
+    private $cluster;
+
+    private $ioContext;
+
+    public function setUp()
+    {
+        $this->cluster = rados_create(getenv('id'));
+        rados_conf_set($this->cluster, "mon_host", getenv('mon_host'));
+        rados_conf_set($this->cluster, "key", getenv('key'));
+        rados_connect($this->cluster);
+        rados_pool_delete($this->cluster, getenv('pool'));
+        rados_pool_create($this->cluster, getenv('pool'));
+        $this->ioContext = rados_ioctx_create($this->cluster, getenv('pool'));
+    }
+
+    public function tearDown()
+    {
+        rados_pool_delete($this->cluster, getenv('pool'));
+    }
+
+    public function testListObjects() {
+        $this->givenThereAreObjects(50);
+        $this->assertEquals(50, count(rados_objects_list($this->ioContext)));
+    }
+
+    public function testListObjectsWithLimit() {
+        $this->givenThereAreObjects(50);
+        // Get the full list
+        $fullList = rados_objects_list($this->ioContext);
+
+        // Match up the first 20
+        $first20 = rados_objects_list($this->ioContext, 20);
+
+        $expectedFirst20 = array_splice($fullList, 0, 20);
+
+        $this->assertEquals($expectedFirst20, $first20);
+    }
+
+
+    public function testListObjectsWithStartPosition() {
+        $this->givenThereAreObjects(50);
+        // Get the full list
+        $fullList = rados_objects_list($this->ioContext);
+        $startPositionIndex = 30;
+        $startPositionItem = $fullList[$startPositionIndex];
+
+        // Get the next 10
+        $next10 = rados_objects_list($this->ioContext, 10, $startPositionItem);
+
+        $expectedNext10 = array_splice($fullList, $startPositionIndex + 1, 10);
+        $this->assertEquals($expectedNext10, $next10);
+    }
+
+    private function givenThereAreObjects($count)
+    {
+        for ($i = 0; $i < $count; $i++) {
+            rados_write_full($this->ioContext, 'file'.$i, uniqid());
+        }
+    }
+}


### PR DESCRIPTION
As discussed on issue #23, this PR adds support for paginating the results from `rados_objects_list`. 

With this, `rados_objects_list` now accepts 3 parameters:

1. [Required] IO Context (as before)
2. [Optional] Maximum number of results to return
3. [Optional] Object name to start from (cursor)

For example, if you had 100 objects, with names `file1` to `file100`, you could use `rados_objects_list` in the following ways:

**List all objects**
````php
rados_objects_list($io); // Will return all objects in the store, same as before
````

**List all objects after `file50`**
````php
rados_objects_list($io, 0, 'file50');
````
_Zero indicates no limit._

**List first 10 objects**
````php
rados_objects_list($io, 10); // Will return file 
````

These changes are backwards compatible.

These changes do not alter the ordering of the results (they are still ordered by Rados's derived object hash). 

The number of required arguments to the function has remained the same. 