### PR TITLE
Adds support for getting required alignment of pool

### DIFF
--- a/php_rados.h
+++ b/php_rados.h
@@ -83,6 +83,8 @@ PHP_FUNCTION(rados_ioctx_get_pool_name);
 PHP_FUNCTION(rados_ioctx_get_namespace);
 PHP_FUNCTION(rados_ioctx_set_namespace);
 
+PHP_FUNCTION(rados_ioctx_pool_required_alignment);
+
 extern zend_module_entry rados_module_entry;
 #define phpext_rados_ptr &rados_module_entry;
 

--- a/rados.c
+++ b/rados.c
@@ -260,6 +260,10 @@ ZEND_BEGIN_ARG_INFO(arginfo_rados_ioctx_set_namespace, 0)
     ZEND_ARG_INFO(0, nspace)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_rados_ioctx_pool_required_alignment, 0)
+    ZEND_ARG_INFO(0, cluster)
+ZEND_END_ARG_INFO()
+
 const zend_function_entry rados_functions[] = {
     PHP_FE(rados_create, arginfo_rados_create)
     PHP_FE(rados_create2, arginfo_rados_create2)
@@ -308,6 +312,7 @@ const zend_function_entry rados_functions[] = {
     PHP_FE(rados_ioctx_get_pool_name, arginfo_rados_ioctx_get_pool_name)
     PHP_FE(rados_ioctx_get_namespace, arginfo_rados_ioctx_get_namespace)
     PHP_FE(rados_ioctx_set_namespace, arginfo_rados_ioctx_set_namespace)
+    PHP_FE(rados_ioctx_pool_required_alignment, arginfo_rados_ioctx_pool_required_alignment)
     {NULL, NULL, NULL}
 };
 
@@ -1736,6 +1741,20 @@ PHP_FUNCTION(rados_ioctx_set_namespace)
         ioctx_r->nspace = NULL;
     }
 }
+
+PHP_FUNCTION(rados_ioctx_pool_required_alignment) {
+    php_rados_ioctx *ioctx_r;
+    zval *zioctx;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zioctx) == FAILURE) {
+        RETURN_FALSE;
+    }
+
+    ZEND_FETCH_RESOURCE(ioctx_r, php_rados_ioctx*, &zioctx, -1, PHP_RADOS_IOCTX_RES_NAME, le_rados_ioctx);
+
+    RETURN_LONG(rados_ioctx_pool_required_alignment(ioctx_r->io));
+}
+
 
 PHP_MINIT_FUNCTION(rados)
 {

--- a/test/UnitTest.php
+++ b/test/UnitTest.php
@@ -234,6 +234,13 @@ class RadosTest extends PHPUnit_Framework_TestCase {
         rados_ioctx_set_namespace($ioctx, NULL);
         $this->assertNull(rados_ioctx_get_namespace($ioctx));
     }
+
+    /**
+     * @depends testRadosCreateIoCTX
+     */
+    public function testRadosPoolRequiredAlignment($ioctx) {
+        $this->assertFalse(rados_ioctx_pool_required_alignment($ioctx));
+    }
 }
 
 ?>


### PR DESCRIPTION
This adds support for the Rados method `rados_ioctx_pool_required_alignment`, which you need to know when writing to an erasure coded pool. 

