### PR TITLE
Fixed memory leak in rados_read

### DIFF
--- a/rados.c
+++ b/rados.c
@@ -936,7 +936,8 @@ PHP_FUNCTION(rados_read) {
         add_assoc_string(return_value, "errMessage", errDesc);
     }
     else {
-        RETURN_STRINGL(buffer, response);
+        ZVAL_STRINGL(return_value, buffer, response);
+        efree(buffer);
     }
 }
 


### PR DESCRIPTION
After running into the memory limit while reading large objects from rados, I've tried to identify the issue and discovered that the memory wasn't leaking in my code, but that there seems to be a memory leak in the rados extension. So after some hours of reading about PHP extensions and several attempts of try and error, I found the problem and a solution.

In PHP 7 the "dup" argument to define if a string should be duplicated or not was removed from several functions including `RETURN_STRINGL`. The string is now always duplicated and the memory has to be freed after that. See: https://wiki.php.net/phpng-upgrading

I've tried to free the memory after the `RETURN_STRINGL` function, but that didn't seem to work, I would guess that's because the function call ends after the function, but I wasn't able to find anything about that.

So I've searched for alternative solutions and using the function `ZVAL_STRINGL` the `efree` function works in the next line and the memory stops leaking.

I hope this is a good solution for the problem and I'm sorry for any mistakes, I've never worked with PHP extensions before.