### PR TITLE
Fixed rados_getxattrs array key string length

### DIFF
--- a/rados.c
+++ b/rados.c
@@ -1195,7 +1195,7 @@ PHP_FUNCTION(rados_getxattrs) {
             if (name == NULL) {
                 break;
             }
-            add_assoc_stringl_ex(return_value, name, strlen(name)+1, val, len);
+            add_assoc_stringl_ex(return_value, name, strlen(name), val, len);
         }
     }
     rados_getxattrs_end(iter);


### PR DESCRIPTION
After some strange problems with rados_getxattrs, where I wasn't able to get an element from the returned array I've discovered that there was an invisible character (ASCII: 0)  at the end of the key string. 

It was easy to see what caused this in the phprados extension, the string length for the key buffer is increased by 1 for no obvious reason. Maybe I'm missing something or it is related to the PHP 7 update, but this seems to be unnecessary and leads to some unexpected behaviour.

I've removed the `+1` from the buffer length argument and it works as expected.