### PR TITLE
Fix cluster / io_ctx resource / memory leaks

### DIFF
--- a/php_rados.h
+++ b/php_rados.h
@@ -24,11 +24,13 @@
 typedef struct _php_rados_cluster {
     rados_t cluster;
     bool connected;
+    int ioctx_count;
 } php_rados_cluster;
 
 typedef struct _php_rados_ioctx {
     rados_ioctx_t io;
     char *nspace;
+    php_rados_cluster *cluster;
 } php_rados_ioctx;
 
 PHP_MINIT_FUNCTION(rados);


### PR DESCRIPTION
When the user forgot to call the destroy/shutdown functions, phprados was leaking memory since the instances never get cleaned up. This can be an issue especially when executing in the scope of a long-running process (like as Apache module).

Also introduce a ioctx counter in php_rados_cluster to prevent shutting down with active io contexts.